### PR TITLE
Forward slash removal

### DIFF
--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -7247,7 +7247,7 @@ If only one file is used, this is 1.</rdfs:comment>
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about the parameters that are put into the involved scientific equipment to run it optimally.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>System/Setup Inputs</friendlyName>
+        <friendlyName>System or Setup Inputs</friendlyName>
         <persistentID>TDO:0000406</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -12884,7 +12884,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#MetersPerSecond">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#SpeedUnit"/>
-        <friendlyName>m/s</friendlyName>
+        <friendlyName>m*s^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -9527,7 +9527,7 @@ Reference: Dublin Core: http://www.lub.lu.se/cgi-bin/nmdc.pl</rdfs:comment>
         </rdfs:subClassOf>
         <rdfs:comment>Class containing specific information about the file supplied to the controlling software to run an experiment.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>List Item (Input File/s Info)</friendlyName>
+        <friendlyName>List Item (Input File(s) Info)</friendlyName>
         <persistentID>TDO:0000415</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -14277,7 +14277,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#mm2PerS">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#KinematicViscosityUnit"/>
-        <friendlyName>mm^2/s</friendlyName>
+        <friendlyName>mm^2*s^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -13925,7 +13925,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#Two11dash15slash16">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#ObjectModelName"/>
-        <friendlyName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">211-15/16</friendlyName>
+        <friendlyName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">211-15÷16</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -12920,7 +12920,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#MicronsPerSecond">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#SpeedUnit"/>
-        <friendlyName>µm/s</friendlyName>
+        <friendlyName>µm*s^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -12673,7 +12673,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#MANTUC2442over91">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#MANStandard"/>
-        <friendlyName>TUC 2442/91</friendlyName>
+        <friendlyName>TUC 2442 91</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -14240,7 +14240,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#kgPerm3">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#MassDensityUnit"/>
-        <friendlyName>kg/m^3</friendlyName>
+        <friendlyName>kg*m^(-3)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -6859,7 +6859,7 @@ If only one file is used, this is 1.</rdfs:comment>
         <rdfs:subClassOf rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#EquipmentRelatedName"/>
         <rdfs:comment>The model name of equipment/object, which the company has given to its product.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Equipment/Product Model</friendlyName>
+        <friendlyName>Equipment or Product Model</friendlyName>
         <persistentID>TDO:0000156</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -12929,7 +12929,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#MicronsPerVoltUnit">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#ConversionUnit"/>
-        <friendlyName>µm/V</friendlyName>
+        <friendlyName>µm*V^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -3161,7 +3161,7 @@ The friendly way to identify it.</rdfs:comment>
         <rdfs:subClassOf rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#EquipmentRelatedName"/>
         <rdfs:comment>The type of machine and the way it is referred to. The friendly way to identify it.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Equipment Type/Name</friendlyName>
+        <friendlyName>Equipment Type or Name</friendlyName>
         <persistentID>TDO:0000153</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -9497,7 +9497,7 @@ Reference: Dublin Core: http://www.lub.lu.se/cgi-bin/nmdc.pl</rdfs:comment>
         </rdfs:subClassOf>
         <rdfs:comment>Class containing all information about the file supplied to the controlling software to run an experiment.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Input File/s Info</friendlyName>
+        <friendlyName>Input File(s) Info</friendlyName>
         <persistentID>TDO:0000414</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -12467,7 +12467,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#KiloMetersPerHour">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#SpeedUnit"/>
-        <friendlyName>km/h</friendlyName>
+        <friendlyName>km*h^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -1290,7 +1290,7 @@ Block specimens can have viscoelasticity.</rdfs:comment>
         <rdfs:comment>The principal tribological side/s of interest. Defined by ISO (not US) technical drawing standards.
 Valid after a feature and its side have been defined.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Tribological Interest Side/s</friendlyName>
+        <friendlyName>Tribological Interest Side(s)</friendlyName>
         <persistentID>TDO:0000181</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -13028,7 +13028,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#NewtonPerVoltUnit">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#ConversionUnit"/>
-        <friendlyName>N/V</friendlyName>
+        <friendlyName>N*V^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -2703,7 +2703,7 @@ This has a major influence on the resulting roughness of the sample&apos;s surfa
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about the parameters that are put into the involved scientific equipment to run it optimally.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>System/Setup Inputs</friendlyName>
+        <friendlyName>System or Setup Inputs</friendlyName>
         <persistentID>TDO:0000400</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -13121,7 +13121,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#OneOverMinuteUnit">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#FrequencyUnit"/>
-        <friendlyName>1/min</friendlyName>
+        <friendlyName>min^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -11845,7 +11845,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#DampenedDeadWeightLoadApplication">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#LoadApplicationMethod"/>
-        <friendlyName>Dead Weight/s (Dampened)</friendlyName>
+        <friendlyName>Dead Weight(s) (Dampened)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -3149,7 +3149,7 @@ A value of 100% indicates the tool can be operated continuously without need for
         <rdfs:comment>The type of machine and the way it is referred to.
 The friendly way to identify it.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Equipment/Product Model</friendlyName>
+        <friendlyName>Equipment or Product Model</friendlyName>
         <persistentID>TDO:0000152</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -11909,7 +11909,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#Diamond5micron90degStylus">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#StylusTipType"/>
-        <friendlyName>Diamond 5 µm/90°</friendlyName>
+        <friendlyName>Diamond 5 µm 90°</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -3479,7 +3479,7 @@ More instances of this class could be added if the files are moved/copied to oth
         <rdfs:subClassOf rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#Role"/>
         <rdfs:comment>Instances of this class specify the purpose of generation of a specific output file during conduction of the experiment. Free text allowed.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>File/s Purpose</friendlyName>
+        <friendlyName>File(s) Purpose</friendlyName>
         <persistentID>TDO:0000392</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -9889,7 +9889,7 @@ This array contains one entry for the base body and one entry for the counter bo
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about the parameters that are put into the involved scientific equipment to run it optimally, but are not directly part of achieving the experimental objectives.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>System/Setup Inputs</friendlyName>
+        <friendlyName>System or Setup Inputs</friendlyName>
         <persistentID>TDO:0000426</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -8868,7 +8868,7 @@ For Other Processes: Objects of this class act as the medium around the specimen
         <rdfs:subClassOf rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#CircumstancesCollective"/>
         <rdfs:comment>Class containing information about the parameters that are put into the involved scientific equipment to run it optimally.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>System/Setup Inputs</friendlyName>
+        <friendlyName>System or Setup Inputs</friendlyName>
     </owl:Class>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -14268,7 +14268,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#mlPerHourUnit">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#VolumetricRateUnit"/>
-        <friendlyName>ml/h</friendlyName>
+        <friendlyName>ml*h^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -9599,7 +9599,7 @@ Reference: Dublin Core: http://www.lub.lu.se/cgi-bin/nmdc.pl</rdfs:comment>
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about the file containing the program to run an experiment.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>LabView Program/s Info</friendlyName>
+        <friendlyName>LabView Program(s) Info</friendlyName>
         <persistentID>TDO:0000417</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -13202,7 +13202,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#PercentRHPerVoltUnit">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#ConversionUnit"/>
-        <friendlyName>%/V</friendlyName>
+        <friendlyName>%*V^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -11872,7 +11872,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#DeadWeightLoadApplication">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#LoadApplicationMethod"/>
-        <friendlyName>Dead Weight/s</friendlyName>
+        <friendlyName>Dead Weight(s)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -4269,7 +4269,7 @@ First underground/basement floor has value &quot;-1&quot;</rdfs:comment>
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about the parameters that are put into the involved scientific equipment to run it optimally.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>System/Setup Inputs</friendlyName>
+        <friendlyName>System or Setup Inputs</friendlyName>
         <persistentID>TDO:0000401</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -12947,7 +12947,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#MilimeterPerSecond">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#SpeedUnit"/>
-        <friendlyName>mm/s</friendlyName>
+        <friendlyName>mm*s^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -8916,7 +8916,7 @@ For Other Processes: Objects of this class act as the medium around the specimen
         </rdfs:subClassOf>
         <rdfs:comment>The equipment setting which specifies the temperature setting of a machine.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Target Heating/Cooling Temperature</friendlyName>
+        <friendlyName>Target Heating or Cooling Temperature</friendlyName>
         <persistentID>TDO:0000253</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -13485,7 +13485,7 @@ The axes are the natural ones defined by the manufacturer or when looked at the 
 
     <owl:NamedIndividual rdf:about="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#RevolutionsPerMinute">
         <rdf:type rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#AngularVelocityUnit"/>
-        <friendlyName>1/min</friendlyName>
+        <friendlyName>min^(-1)</friendlyName>
     </owl:NamedIndividual>
     
 

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -8856,7 +8856,7 @@ For Other Processes: Objects of this class act as the medium around the specimen
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about the parameters that are put into the involved scientific equipment to run it optimally.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>System/Setup Inputs</friendlyName>
+        <friendlyName>System or Setup Inputs</friendlyName>
         <persistentID>TDO:0000409</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -7003,7 +7003,7 @@ If only one file is used, this is 1.</rdfs:comment>
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about who performed a scientific process, or is responsible for an object.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Operator/s in Charge</friendlyName>
+        <friendlyName>Operator(s) in Charge</friendlyName>
         <persistentID>TDO:0000441</persistentID>
     </owl:Class>
     

--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -5728,7 +5728,7 @@ For Tribometers, the way the normal load is applied can have a big influence on 
         <rdfs:subClassOf rdf:resource="https://www.iam.kit.edu/cms/download/TriboDataFAIR_Ontology.owl#SpecimenRelatedName"/>
         <rdfs:comment>The official name of the insitution where the object was manufactured.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>Company/Vendor Name</friendlyName>
+        <friendlyName>Company or Vendor Name</friendlyName>
         <persistentID>TDO:0000155</persistentID>
     </owl:Class>
     


### PR DESCRIPTION
Replaced the forward slashes ('/') in the friendlyName's in the ontology with appropriate symbols.