### PR TITLE
Updated the friendlyName of TribologicalExperimentLabviewFileArray

### DIFF
--- a/TriboDataFAIR_Ontology.owl
+++ b/TriboDataFAIR_Ontology.owl
@@ -9647,7 +9647,7 @@ Reference: Dublin Core: http://www.lub.lu.se/cgi-bin/nmdc.pl</rdfs:comment>
         </rdfs:subClassOf>
         <rdfs:comment>Class containing information about the file containing the program to run an experiment.</rdfs:comment>
         <definitionOrigin>TriboData Team at IAM-CMS at KIT, Karlsruhe, Germany</definitionOrigin>
-        <friendlyName>LabVIEW Program/s Info</friendlyName>
+        <friendlyName>LabVIEW Program(s) Info</friendlyName>
         <persistentID>TDO:0000417</persistentID>
     </owl:Class>
     


### PR DESCRIPTION
Updated the friendlyName of TribologicalExperimentLabviewFileArray from "LabVIEW Program/s Info" to "LabVIEW Program(s) Info".
The friendlyName above was reverted after I had removed the forward slash, so I'm updating it again.